### PR TITLE
[SMV-578] 특정 빌드러너 지정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, macos]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Feature link

- https://shoplive.atlassian.net/browse/SMV-578

### PR 간단하게 설명 해주세요.

- 공유 빌드 러너로 돌면 android sdk 환경설정이 안되있고 라이브러리도 없습니다.
  우리 빌드러너로 지정할 수 있는 값을 특정했습니다.



### PR 에 포함 될 유틸 중 유용하게 쓰일 상황 있다면 말해주세요.

- 유틸 설명 쓰는 부분



### 테스트 진행 여부

- [ ] 개발 서버 테스트 완료
- [ ] 실서버 테스트 완료
